### PR TITLE
[Bug]: Pages Should Be Returned Consistently

### DIFF
--- a/WikiForGToolkit.package/WkClassWiki.class/instance/page..st
+++ b/WikiForGToolkit.package/WkClassWiki.class/instance/page..st
@@ -1,6 +1,8 @@
 accessing
 page: aSymbol
 	aSymbol = #Main
-		ifTrue: [ ^ self wikiClass comment ].
+		ifTrue:
+			[ ^ APWikiPage wiki: self name: #Main text: self wikiClass comment ].
 	^ [ self wikiClass perform: (self methodSelectorForPage: aSymbol) ]
-		on: MessageNotUnderstood do: [ nil ]
+		on: MessageNotUnderstood
+		do: [ nil ]

--- a/WikiForGToolkit.package/WkWikiStorageStrategy.class/instance/read..st
+++ b/WikiForGToolkit.package/WkWikiStorageStrategy.class/instance/read..st
@@ -1,3 +1,3 @@
 actions
 read: aDocument
-	aDocument text: (wiki page: pageName)
+	aDocument text: (wiki page: pageName) text


### PR DESCRIPTION
The main page was returned as a string, but other pages are page objects